### PR TITLE
Tave Intel env

### DIFF
--- a/env.tave.gnu.sh
+++ b/env.tave.gnu.sh
@@ -6,13 +6,11 @@ else
     module swap ${prgenv} PrgEnv-gnu
 fi
 
+module load cray-mpich
 module load CMake
 
 # Boost
 export BOOST_ROOT=/scratch/snx2000/jenkins/install/boost/boost_1_64_0
 export LD_LIBRARY_PATH=${BOOST_ROOT}/lib:${LD_LIBRARY_PATH}
 
-# Override C++ and C compiler
-export CXX=`which g++`
-export CC=`which gcc`
 export FC=ftn

--- a/env.tave.intel.sh
+++ b/env.tave.intel.sh
@@ -7,6 +7,7 @@ else
 fi
 module swap intel intel/18.0.2.199
 module load gcc # for recent STL
+module load cray-mpich
 
 module load CMake
 
@@ -14,13 +15,4 @@ module load CMake
 export BOOST_ROOT=/scratch/snx2000/jenkins/install/boost/boost_1_64_0
 export LD_LIBRARY_PATH=${BOOST_ROOT}/lib:${LD_LIBRARY_PATH}
 
-# Override C++ and C compiler
-export CXX=`which icpc`
-export CC=`which icc`
-export FC=`which ifort`
-
-# Override flags
-flags="-xmic-avx512"
-export CXXFLAGS="$flags"
-export CFLAGS="$flags"
-export FFLAGS="$flags"
+export FC=`which gfortran`

--- a/env.tave.intel.sh
+++ b/env.tave.intel.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+prgenv=`module list -t 2>&1 | grep 'PrgEnv-'`
+if [ -z "${prgenv}" ]; then
+    module load PrgEnv-intel
+else
+    module swap ${prgenv} PrgEnv-intel
+fi
+module swap intel intel/18.0.2.199
+module load gcc # for recent STL
+
+module load CMake
+
+# Boost
+export BOOST_ROOT=/scratch/snx2000/jenkins/install/boost/boost_1_64_0
+export LD_LIBRARY_PATH=${BOOST_ROOT}/lib:${LD_LIBRARY_PATH}
+
+# Override C++ and C compiler
+export CXX=`which icpc`
+export CC=`which icc`
+export FC=`which ifort`
+
+# Override flags
+flags="-xmic-avx512"
+export CXXFLAGS="$flags"
+export CFLAGS="$flags"
+export FFLAGS="$flags"


### PR DESCRIPTION
Add an Intel environment for Tavé and further fixes MPI compilation for the Tavé GNU environment.