### PR TITLE
Fixes to support MPI in dycore

### DIFF
--- a/env.daint.gnu.sh
+++ b/env.daint.gnu.sh
@@ -13,9 +13,6 @@ module load CMake
 export BOOST_ROOT=/scratch/snx3000/jenkins/install/boost/boost_1_64_0
 export LD_LIBRARY_PATH=${BOOST_ROOT}/lib:${LD_LIBRARY_PATH}
 
-# Override C++ and C compiler
-export CXX=`which g++`
-export CC=`which gcc`
 export FC=ftn
-export USE_MPI_COMPILER=OFF
-export HOST_COMPILER=`which CC`
+# We cannot simply use g++ as cuda host compiler, because we require MPI support
+export CUDAHOSTCXX=CC

--- a/env.daint.gnu.sh
+++ b/env.daint.gnu.sh
@@ -17,3 +17,5 @@ export LD_LIBRARY_PATH=${BOOST_ROOT}/lib:${LD_LIBRARY_PATH}
 export CXX=`which g++`
 export CC=`which gcc`
 export FC=ftn
+export USE_MPI_COMPILER=OFF
+export HOST_COMPILER=`which CC`

--- a/env.kesch.gnu.5.4.0.sh
+++ b/env.kesch.gnu.5.4.0.sh
@@ -17,7 +17,7 @@ module load hdf5/1.8.18-gmvolf-17.02
 export LD_LIBRARY_PATH=${CRAY_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}
 
 # Boost
-export BOOST_ROOT=/project/c14/install/kesch-test/boost/boost_1_64_0/
+export BOOST_ROOT=/project/c14/install/kesch/boost/boost_1_64_0/
 export LD_LIBRARY_PATH=${BOOST_ROOT}/lib:${LD_LIBRARY_PATH}
 
 # Add an explicit linker line for GCC to provide C++11 support
@@ -28,4 +28,3 @@ export CXX=`which g++`
 export CC=`which gcc`
 export FC=`which gfortran`
 export LINKER_X86_64=$(which ld)
-export HOST_COMPILER=`which g++`

--- a/env.kesch.gnu.5.4.0.sh
+++ b/env.kesch.gnu.5.4.0.sh
@@ -28,3 +28,4 @@ export CXX=`which g++`
 export CC=`which gcc`
 export FC=`which gfortran`
 export LINKER_X86_64=$(which ld)
+export HOST_COMPILER=`which g++`


### PR DESCRIPTION
Fix environment: Use MPI-Wrappers on daint and fix BOOST_ROOT on kesch.